### PR TITLE
Benchmarking script for Pillow

### DIFF
--- a/pillow.py
+++ b/pillow.py
@@ -1,0 +1,24 @@
+#!/usr/bin/python 
+
+import Image, sys
+import ImageFilter 
+
+im = Image.open (sys.argv[1])
+
+# Crop 100 pixels off all edges.
+im = im.crop ((100, 100, im.size[0] - 100, im.size[1] - 100))
+
+# Shrink by 10%
+im = im.resize ((int (im.size[0] * 0.9), int (im.size[1] * 0.9)),
+        Image.BILINEAR) 
+
+# sharpen
+filter = ImageFilter.Kernel ((3, 3),
+	      (-1, -1, -1,
+	       -1, 16, -1,
+	       -1, -1, -1))
+im = im.filter (filter)
+
+# write back again
+im.save (sys.argv[2])
+

--- a/pillow.py
+++ b/pillow.py
@@ -1,7 +1,7 @@
-#!/usr/bin/python 
+#!/usr/bin/python
 
-import Image, sys
-import ImageFilter 
+import sys
+from PIL import Image, ImageFilter
 
 im = Image.open (sys.argv[1])
 
@@ -10,7 +10,7 @@ im = im.crop ((100, 100, im.size[0] - 100, im.size[1] - 100))
 
 # Shrink by 10%
 im = im.resize ((int (im.size[0] * 0.9), int (im.size[1] * 0.9)),
-        Image.BILINEAR) 
+        Image.BILINEAR)
 
 # sharpen
 filter = ImageFilter.Kernel ((3, 3),


### PR DESCRIPTION
PIL hasn't had any releases in five years. Pillow is a maintained fork.

The only difference to the PIL test is the imports. To run, make sure to uninstall PIL first, then `pip install pillow`. More details here: http://pillow.readthedocs.org/installation.html

It'd be interesting to see Pillow added to the results as well as PIL here: http://www.vips.ecs.soton.ac.uk/index.php?title=Speed_and_Memory_Use